### PR TITLE
Adding a configuration option to provide the MongoDB database name when it's absent on the connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ In your Package Manager settings add the following package source for developmen
               collectionName="String"
               cappedCollectionSize="Long"
               cappedCollectionMaxItems="Long"
+              databaseName="String"
               includeDefaults="Boolean">
         
         <!-- repeated --> 
@@ -62,6 +63,8 @@ _name_ - Name of the target.
 _connectionName_ - The name of the connection string to get from the config file. 
 
 _connectionString_ - Connection string. When provided, it overrides the values specified in connectionName. 
+
+_databaseName_ - The name of the database.  If provided in the connection string, it will be used.  If not, it will use the default value, "NLog".
 
 ###Collection Options
 _collectionName_ - The name of the MongoDB collection to write logs to.  
@@ -133,8 +136,9 @@ _property_ - Specifies a dictionary property on the Properties field. There can 
     <target xsi:type="Mongo"
             name="mongoCustom"
             includeDefaults="false"
-            connectionString="mongodb://localhost/Logging"
+            connectionString="mongodb://localhost"
             collectionName="CustomLog"
+            databaseName="Logging"
             cappedCollectionSize="26214400">
       <field name="Date" layout="${date}" bsonType="DateTime" />
       <field name="Level" layout="${level}"/>

--- a/Source/net40/NLog.Mongo.ConsoleTest/NLog.config
+++ b/Source/net40/NLog.Mongo.ConsoleTest/NLog.config
@@ -22,6 +22,20 @@
       </target>
     </target>
 
+    <target name="mongoDefaultCustomDatabase" xsi:type="AsyncWrapper">
+      <target xsi:type="Mongo"
+              connectionString="mongodb://localhost"
+              databaseName="CustomLogging"
+              collectionName="DefaultLog"
+              cappedCollectionSize="26214400">
+        <property name="ThreadID" layout="${threadid}" bsonType="Int32" />
+        <property name="ThreadName" layout="${threadname}" />
+        <property name="ProcessID" layout="${processid}" bsonType="Int32"  />
+        <property name="ProcessName" layout="${processname:fullName=true}" />
+        <property name="UserName" layout="${windows-identity}" />
+      </target>
+    </target>
+
     <target xsi:type="Mongo"
             name="mongoCustom"
             includeDefaults="false"

--- a/Source/net45/NLog.Mongo.ConsoleTest/NLog.config
+++ b/Source/net45/NLog.Mongo.ConsoleTest/NLog.config
@@ -22,6 +22,20 @@
       </target>
     </target>
 
+    <target name="mongoDefaultCustomDatabase" xsi:type="AsyncWrapper">
+      <target xsi:type="Mongo"
+              connectionString="mongodb://localhost"
+              databaseName="CustomLogging"
+              collectionName="DefaultLog"
+              cappedCollectionSize="26214400">
+        <property name="ThreadID" layout="${threadid}" bsonType="Int32" />
+        <property name="ThreadName" layout="${threadname}" />
+        <property name="ProcessID" layout="${processid}" bsonType="Int32"  />
+        <property name="ProcessName" layout="${processname:fullName=true}" />
+        <property name="UserName" layout="${windows-identity}" />
+      </target>
+    </target>
+
     <target xsi:type="Mongo"
             name="mongoCustom"
             includeDefaults="false"
@@ -62,6 +76,7 @@
 
   <rules>
     <logger name="*" minlevel="Trace" writeTo="mongoDefault" />
+    <logger name="*" minlevel="Trace" writeTo="mongoDefaultCustomDatabase" />
     <logger name="*" minlevel="Trace" writeTo="mongoCustom" />
     <logger name="*" minlevel="Debug" writeTo="console" />
     <logger name="*" minlevel="Trace" writeTo="rollingFile" />


### PR DESCRIPTION
In my case, we use a single connection string to access several MongoDB databases.  With this pull request, the default database name (NLog) can be changed.