### PR TITLE
Added JsonLayout support for Field and Property using BsonType=Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ _includeEventProperties_ - Specifies if LogEventInfo Properties should be automa
 }
 ```
 
-### Complete Custom Document
+### Custom Document Fields
 
 #### NLog.config target
 
@@ -158,7 +158,7 @@ _includeEventProperties_ - Specifies if LogEventInfo Properties should be automa
 </target>
 ```
 
-#### Custom Output JSON
+#### Custom Document Fields JSON output
 
 ```JSON
 {
@@ -171,5 +171,54 @@ _includeEventProperties_ - Specifies if LogEventInfo Properties should be automa
     "ProcessID" : 26604,
     "ProcessName" : "C:\\Projects\\github\\NLog.Mongo\\Source\\NLog.Mongo.ConsoleTest\\bin\\Debug\\v4.5\\NLog.Mongo.ConsoleTest.exe",
     "UserName" : "pwelter"
+}
+```
+
+### Custom Object Properties
+
+#### NLog.config target
+
+```xml
+<target xsi:type="Mongo"
+        name="mongoCustomJsonProperties"
+        includeEventProperties="false"
+        connectionString="mongodb://localhost"
+        collectionName="CustomLog"
+        databaseName="Logging"
+        cappedCollectionSize="26214400">
+    <field name="Properties" bsonType="Object">
+        <layout type="JsonLayout" includeAllProperties="true" includeMdlc="true" maxRecursionLimit="10">
+            <attribute name="ThreadID" layout="${threadid}" encode="false" />
+            <attribute name="ProcessID" layout="${processid}" encode="false" />
+            <attribute name="ProcessName" layout="${processname:fullName=false}" />
+        </layout>
+    </field>
+</target>
+```
+
+#### Custom Object Properties JSON output
+
+```JSON
+{
+    "_id" : ObjectId("5184219b545eb455aca34390"),
+    "Date" : ISODate("2013-05-03T20:44:11Z"),
+    "Level" : "Error",
+    "Logger" : "NLog.Mongo.ConsoleTest.Program",
+    "Message" : "Error reading file 'blah.txt'.",
+    "Exception" : {
+        "Message" : "Could not find file 'C:\\Projects\\github\\NLog.Mongo\\Source\\NLog.Mongo.ConsoleTest\\bin\\Debug\\blah.txt'.",
+        "Text" : "System.IO.FileNotFoundException: Could not find file 'C:\\Projects\\github\\NLog.Mongo\\Source\\NLog.Mongo.ConsoleTest\\bin\\Debug\\blah.txt' ...",
+        "Type" : "System.IO.FileNotFoundException",
+        "Source" : "mscorlib",
+        "MethodName" : "WinIOError",
+        "ModuleName" : "mscorlib",
+        "ModuleVersion" : "4.0.0.0"
+    },
+    "Properties" : {
+        "ThreadID" : 10,
+        "ProcessID" : 21932,
+        "ProcessName" : "NLog.Mongo.ConsoleTest.exe",
+        "Product": { "Name": "Foo", "Id": 42 }
+    }
 }
 ```

--- a/src/NLog.Mongo/MongoConvert.cs
+++ b/src/NLog.Mongo/MongoConvert.cs
@@ -22,7 +22,7 @@ namespace NLog.Mongo
             bool result;
             if (bool.TryParse(value, out result))
             {
-                bsonValue = new BsonBoolean(true);
+                bsonValue = new BsonBoolean(result);
                 return true;
             }
 
@@ -108,5 +108,29 @@ namespace NLog.Mongo
             return r;
         }
 
+        /// <summary>Try to convert the string to a <see cref="BsonDocument"/>.</summary>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="bsonValue">The BsonValue result.</param>
+        /// <returns><c>true</c> if the value was converted; otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// BsonDocument will by default convert normal Json-formatted DateTime-/DateTimerOffset-values as BsonString-values.
+        /// BsonDocument has special requirements for recognizing DateTime-/DateTimerOffset-values.
+        /// </remarks>
+        public static bool TryJsonObject(this string value, out BsonValue bsonValue)
+        {
+            bsonValue = null;
+            if (value == null)
+                return false;
+
+            try
+            {
+                bsonValue = BsonDocument.Parse(value);
+                return bsonValue != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/NLog.Mongo/MongoField.cs
+++ b/src/NLog.Mongo/MongoField.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using NLog.Config;
 using NLog.Layouts;
 
@@ -67,6 +68,43 @@ namespace NLog.Mongo
         /// The bson type of the field..
         /// </value>
         [DefaultValue("String")]
-        public string BsonType { get; set; }
+        public string BsonType
+        {
+            get => _bsonType;
+            set
+            { 
+                _bsonType = value;
+                BsonTypeCode = ConvertToTypeCode(value?.Trim() ?? string.Empty);
+            }
+        }
+        private string _bsonType;
+
+        internal TypeCode BsonTypeCode { get; private set; } = TypeCode.String;
+
+        private TypeCode ConvertToTypeCode(string bsonType)
+        {
+            if (string.IsNullOrEmpty(bsonType) || string.Equals(bsonType, "String", StringComparison.OrdinalIgnoreCase))
+                return TypeCode.String;
+
+            if (string.Equals(bsonType, "Boolean", StringComparison.OrdinalIgnoreCase))
+                return TypeCode.Boolean;
+
+            if (string.Equals(bsonType, "DateTime", StringComparison.OrdinalIgnoreCase))
+                return TypeCode.DateTime;
+
+            if (string.Equals(bsonType, "Double", StringComparison.OrdinalIgnoreCase))
+                return TypeCode.Double;
+
+            if (string.Equals(bsonType, "Int32", StringComparison.OrdinalIgnoreCase))
+                return TypeCode.Int32;
+
+            if (string.Equals(bsonType, "Int64", StringComparison.OrdinalIgnoreCase))
+                return TypeCode.Int64;
+
+            if (string.Equals(bsonType, "Object", StringComparison.OrdinalIgnoreCase))
+                return TypeCode.Object;
+
+            return TypeCode.String;
+        }
     }
 }

--- a/test/NLog.Mongo.ConsoleTest/NLog.config
+++ b/test/NLog.Mongo.ConsoleTest/NLog.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" throwOnConfigExceptions="true">
 
   <variable name="logDirectory" value="${basedir}/Logs" />
 
@@ -56,6 +56,22 @@
 
     </target>
 
+    <target xsi:type="Mongo"
+            name="mongoCustomJsonProperties"
+            includeEventProperties="false"
+            connectionString="mongodb://localhost/Logging"
+            collectionName="CustomLog"
+            cappedCollectionSize="26214400">
+        <field name="Properties" bsonType="Object">
+          <layout type="JsonLayout" includeAllProperties="true" includeMdlc="true" maxRecursionLimit="10">
+            <attribute name="ThreadID" layout="${threadid}" encode="false" />
+            <attribute name="ProcessID" layout="${processid}" encode="false" />
+            <attribute name="ProcessName" layout="${processname:fullName=false}" />
+          </layout>
+        </field>
+    </target>
+    
+    
     <target name="rollingFile"
             xsi:type="File"
             layout="${longdate} ${threadid:padding=4} ${level:uppercase=true:padding=5} ${logger} ${message} ${exception:format=tostring}"
@@ -78,6 +94,7 @@
     <logger name="*" minlevel="Trace" writeTo="mongoDefault" />
     <logger name="*" minlevel="Trace" writeTo="mongoDefaultCustomDatabase" />
     <logger name="*" minlevel="Trace" writeTo="mongoCustom" />
+    <logger name="*" minlevel="Trace" writeTo="mongoCustomJsonProperties" />
     <logger name="*" minlevel="Debug" writeTo="console" />
     <logger name="*" minlevel="Trace" writeTo="rollingFile" />
   </rules>


### PR DESCRIPTION
Adding support for complex objects in `LogEventInfo.Properties` with help from `JsonLayout`.

```xml
    <target xsi:type="Mongo"
            name="mongoCustomJsonProperties"
            includeEventProperties="false"
            connectionString="mongodb://localhost/Logging"
            collectionName="CustomLog"
            cappedCollectionSize="26214400">
        <field name="Properties" bsonType="Object">
          <layout type="JsonLayout" includeAllProperties="true" includeMdlc="true" maxRecursionLimit="10">
            <attribute name="ThreadID" layout="${threadid}" encode="false" />
            <attribute name="ProcessID" layout="${processid}" encode="false" />
            <attribute name="ProcessName" layout="${processname:fullName=false}" />
          </layout>
        </field>
    </target>
```

BsonDocument will by default convert normal Json-formatted DateTime-/DateTimerOffset-values as BsonString-values.
- BsonDocument has special requirements for recognizing DateTime-/DateTimerOffset-values.