### PR TITLE
Support datetime layout logic for collection-name

### DIFF
--- a/src/NLog.Mongo/MongoTarget.cs
+++ b/src/NLog.Mongo/MongoTarget.cs
@@ -195,7 +195,7 @@ namespace NLog.Mongo
                     _createDocumentDelegate = e => CreateDocument(e.LogEvent);
 
                 var documents = logEvents.Select(_createDocumentDelegate);
-                var collection = GetCollection();
+                var collection = GetCollection(logEvents[logEvents.Count - 1].LogEvent.TimeStamp);
                 collection.InsertMany(documents);
 
                 for (int i = 0; i < logEvents.Count; ++i)
@@ -226,7 +226,7 @@ namespace NLog.Mongo
             try
             {
                 var document = CreateDocument(logEvent);
-                var collection = GetCollection();
+                var collection = GetCollection(logEvent.TimeStamp);
                 collection.InsertOne(document);
             }
             catch (Exception ex)
@@ -392,8 +392,11 @@ namespace NLog.Mongo
             return bsonValue ?? new BsonString(value);
         }
 
-        private IMongoCollection<BsonDocument> GetCollection()
+        private IMongoCollection<BsonDocument> GetCollection(DateTime timestamp)
         {
+            if (_defaultLogEvent.TimeStamp < timestamp)
+                _defaultLogEvent.TimeStamp = timestamp;
+
             string connectionString = _connectionString != null ? RenderLogEvent(_connectionString, _defaultLogEvent) : string.Empty;
             string collectionName = _collectionName != null ? RenderLogEvent(_collectionName, _defaultLogEvent) : string.Empty;
             string databaseName = _databaseName != null ? RenderLogEvent(_databaseName, _defaultLogEvent) : string.Empty;


### PR DESCRIPTION
Allow using `${shortdate}` in CollectionName:

```xml
    <target xsi:type="Mongo"
            name="mongo"
            includeDefaults="false"
            connectionString="mongodb://localhost/financeLogs"
            collectionName="log-${shortdate}"
            databaseName="financeLogs">
        <property name="LongDate" layout="${longdate}" bsonType="DateTime" />
        <property name="Level" layout="${level}"/>
        <property name="Message" layout="${message}"/>
    </target>
```

See also: https://stackoverflow.com/questions/64410247/nlog-mongodb-create-collection