### PR TITLE
Added support for suffix on database and/or collection

### DIFF
--- a/test/NLog.Mongo.Tests/LoggerTest.cs
+++ b/test/NLog.Mongo.Tests/LoggerTest.cs
@@ -23,6 +23,32 @@ public class LoggerTest
             .Property("Test", "Tesing properties")
             .Log();
 
+        string t = "tenant1";
+        // The property name must match the one written in the NLog.config
+        using (ScopeContext.PushProperty("TenantId", t))
+        {
+            _logger.Trace("Sample trace message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Debug("Sample debug message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Info("Sample informational message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Warn("Sample warning message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Error("Sample error message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Fatal("Sample fatal error message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Log(LogLevel.Info, "Sample fatal error message, k={0}, l={1}, t={2}", k, l, t);
+        }
+
+        t = "tenant2";
+        // The property name must match the one written in the NLog.config
+        using (ScopeContext.PushProperty("TenantId", t))
+        {
+            _logger.Trace("Sample trace message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Debug("Sample debug message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Info("Sample informational message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Warn("Sample warning message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Error("Sample error message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Fatal("Sample fatal error message, k={0}, l={1}, t={2}", k, l, t);
+            _logger.Log(LogLevel.Info, "Sample fatal error message, k={0}, l={1}, t={2}", k, l, t);
+        }
+
         string path = "blah.txt";
 
         try

--- a/test/NLog.Mongo.Tests/NLog.config
+++ b/test/NLog.Mongo.Tests/NLog.config
@@ -71,7 +71,6 @@
         </field>
     </target>
     
-    
     <target name="rollingFile"
             xsi:type="File"
             layout="${longdate} ${threadid:padding=4} ${level:uppercase=true:padding=5} ${logger} ${message} ${exception:format=tostring}"
@@ -88,6 +87,24 @@
             name="console"
             layout="${time} ${level:uppercase=true:padding=1:fixedLength=true} ${logger:shortName=true} ${message} ${exception:format=tostring}"/>
 
+    <target xsi:type="Mongo"
+            name="mongoCustomDatabaseWithSuffix"
+            includeEventProperties="false"
+            connectionString="mongodb://localhost/Logging"
+            databaseName="CustomLogging"
+            collectionName="CustomLog"
+            cappedCollectionSize="26214400"
+            databaseSuffixProperty="TenantId">
+      <field name="TenantId" bsonType="String" layout="${scope-property:TenantId}" />
+      <field name="Properties" bsonType="Object">
+        <layout type="JsonLayout" includeAllProperties="true" includeMdlc="true" maxRecursionLimit="10">
+          <attribute name="ThreadID" layout="${threadid}" encode="false" />
+          <attribute name="ProcessID" layout="${processid}" encode="false" />
+          <attribute name="ProcessName" layout="${processname:fullName=false}" />
+        </layout>
+      </field>
+    </target>
+
   </targets>
 
   <rules>
@@ -97,5 +114,6 @@
     <logger name="*" minlevel="Trace" writeTo="mongoCustomJsonProperties" />
     <logger name="*" minlevel="Debug" writeTo="console" />
     <logger name="*" minlevel="Trace" writeTo="rollingFile" />
+    <logger name="*" minlevel="Trace" writeTo="mongoCustomDatabaseWithSuffix" />
   </rules>
 </nlog>


### PR DESCRIPTION
## Summary
This PR introduces the ability to add dynamic suffixes to MongoDB database name and/or collection names in the NLog.Mongo target, enabling more flexible log organization and partitioning strategies (ex. multi tenants)

## Changes Made
- Added `databaseSuffixProperty` and `collectionSuffixProperty` to `MongoTarget` to identify which bson property needs to be read to get the suffix.
- Updated the collection and database's resolution based on the properties above
- Updated tests to validate suffix functionality and to show how to configure the property

Fully backward compatible

